### PR TITLE
Fix for super class mismatch error

### DIFF
--- a/app/models/civo/disk_image.rb
+++ b/app/models/civo/disk_image.rb
@@ -7,6 +7,4 @@ module Civo
       "civo/disk_image"
     end
   end
-
-  class DiskImage < DiskImage ; end
 end

--- a/lib/civo/version.rb
+++ b/lib/civo/version.rb
@@ -1,3 +1,3 @@
 module Civo
-  VERSION = "1.4.1"
+  VERSION = "1.4.2"
 end


### PR DESCRIPTION
It fixes `<module:Civo>': superclass mismatch for class DiskImage (TypeError) ` error